### PR TITLE
Fix GitHub URL in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule PrometheusCowboy.Mixfile do
   defp package do
     [maintainers: ["Ilya Khaprov"],
      licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/deadtrickster/prometheus_cowboy"},
+     links: %{"GitHub" => "https://github.com/deadtrickster/prometheus-cowboy"},
      files: ["src", "lib", "README.md", "rebar.config"]]
   end
 


### PR DESCRIPTION
Hi.

I tried to access this repository url from [hex.pm](https://hex.pm/packages/prometheus_cowboy) but I got `404 not found`.
This problem would be solved simply, just replacing `_` to `-`. 👍

Thanks!