### PR TITLE
Accept binary status codes

### DIFF
--- a/src/prometheus_cowboy2_instrumenter.erl
+++ b/src/prometheus_cowboy2_instrumenter.erl
@@ -237,8 +237,10 @@ label_value(port, #{listener_port:=Port}) ->
   Port;
 label_value(method, #{req:=Req}) ->
   cowboy_req:method(Req);
-label_value(status, #{resp_status:=Status}) ->
+label_value(status, #{resp_status:=Status}) when is_integer(Status) ->
   Status;
+label_value(status, #{resp_status:=Status}) when is_binary(Status) ->
+  undefined;
 label_value(status_class, #{resp_status:=undefined}) ->
   undefined;
 label_value(status_class, #{resp_status:=Status}) ->


### PR DESCRIPTION
As the cowboy docs say:

> A binary status can be used to set a reason phrase.

Currently, setting a binary phrase will crash `cowboy_metrics_h`.
This PR addresses this.

https://ninenines.eu/docs/en/cowboy/2.6/manual/cowboy/#_http_status