### PR TITLE
squash! Accept binary status codes

### DIFF
--- a/src/prometheus_cowboy2_instrumenter.erl
+++ b/src/prometheus_cowboy2_instrumenter.erl
@@ -237,13 +237,13 @@ label_value(port, #{listener_port:=Port}) ->
   Port;
 label_value(method, #{req:=Req}) ->
   cowboy_req:method(Req);
-label_value(status, #{resp_status:=Status}) when is_integer(Status) ->
+label_value(status, #{resp_status:=Status}) ->
   Status;
-label_value(status, #{resp_status:=Status}) when is_binary(Status) ->
-  undefined;
 label_value(status_class, #{resp_status:=undefined}) ->
   undefined;
-label_value(status_class, #{resp_status:=Status}) ->
+label_value(status_class, #{resp_status:=Status}) when is_binary(Status) ->
+  undefined;
+label_value(status_class, #{resp_status:=Status}) when is_integer(Status) ->
   prometheus_http:status_class(Status);
 label_value(reason, #{reason:=Reason}) ->
   case Reason of


### PR DESCRIPTION
This PR amends https://github.com/deadtrickster/prometheus-cowboy/pull/4

After running the code for a bit, I realised that it is the `status_class` value that caused problems with binary status codes, not `status`.

I should've looked into it more before submitting the last PR. Sorry about that.